### PR TITLE
Festival overview & Festival detail page

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ app.get("/api/festivals/", async (_request, response) => {
 });
 
 // Read one festival with mongoDB
-app.get("/api/festivals/:name", async (request, response) => {
+app.get("/api/festivals/name/:name", async (request, response) => {
   const festivalCollection = getFestivalCollection();
   const festival = request.params.name;
 

--- a/src/components/FestivalCardLarge/FestivalCardLarge.module.css
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.module.css
@@ -1,11 +1,12 @@
 .container {
-  width: 366px;
+  width: 375px;
 }
 
 .wrapper {
+  position: relative;
   display: grid;
   background-color: var(--color-neutral-grade);
-  padding: 1.1rem 1.3rem;
+  padding: 1.75rem 1.5rem;
   border-radius: 1.25rem;
   width: 90%;
   gap: 2rem;
@@ -17,8 +18,10 @@
 }
 
 .close {
-  justify-self: end;
-  height: 90%;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  height: 1.8rem;
 }
 
 .title {

--- a/src/components/FestivalCardLarge/FestivalCardLarge.module.css
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.module.css
@@ -27,7 +27,7 @@
 
 .list {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 35% 1fr;
   grid-template-rows: 1fr;
 }
 

--- a/src/components/FestivalCardLarge/FestivalCardLarge.module.css
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.module.css
@@ -46,8 +46,3 @@
   composes: text-info from global;
   padding: 0.25rem 0;
 }
-
-.button {
-  display: grid;
-  justify-items: center;
-}

--- a/src/components/FestivalCardLarge/FestivalCardLarge.stories.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.stories.tsx
@@ -5,4 +5,16 @@ export default {
   title: "Components/Festival Card Large",
 };
 
-export const Card = () => <FestivalCardLarge />;
+export const Card = () => (
+  <FestivalCardLarge
+    name="Summer Breeze"
+    location="Dinkelsbühl"
+    begin="17.08.2022"
+    end="20.08.2022"
+    visitors={45000}
+    acts={140}
+    price={170}
+    allacts="Acranius, Agrypnie, Alestorm, Amorphis, Angelus Apatrida, Any Given Day, Die Apokalyptischen Reiter, Arch Enemy, Avatarium, Beast In Black, Benediction, Benighted, Blind Guardian, Bloodywood, Born From Pain, Brainstorm, Brothers Of Metal, Bury Tomorrow, Caliban, Cannibal Corpse, Combichrist, Comeback Kid, Conjurer, Crisix, Cypecore, Cytotoxin, Dagoba, Dangerface, Dark Funeral, Dark Tranquillity, Death Angel, Debauchery, Distant, Djerv, Eisbrecher, Eisregen, Emil Bulls, Enforced, Ensiferum, Feuerschwanz, Fiddler’s Green, Finntroll, Ghostkid, Gutalax, Hämatom, Haggefugg, Hammer King, Hangman’s Chair, Hatebreed, Heaven Shall Burn, Humanity’s Last Breath, Hypocrisy, Igorrr, Infected Rain, Insomnium, J.B.O., Jinjer, Korpiklaani, Landmvrks, Lik, Lord Of The Lost, Lorna Shore, Lüt, Madball, Mass Hysteria, Mental Cruelty, Misery Index, Mission In Black, Mr. Hurley & Die Pulveraffen, Napalm Death, Necrotted, Omnium Gatherum, Orden Ogan, Parasite Inc., Primal Fear, Seasons In Black, Serenity, Skyeye, Slope, Static X, Thundermother, Vola, Vulture, Warkings, Der Weg einer Freiheit, Within Temptation"
+    website="www.summer-breeze.de"
+  />
+);

--- a/src/components/FestivalCardLarge/FestivalCardLarge.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.tsx
@@ -1,4 +1,3 @@
-import Button from "../Buttons/Button";
 import styles from "./FestivalCardLarge.module.css";
 
 export type FestivalCardLargeProps = {
@@ -11,7 +10,7 @@ export type FestivalCardLargeProps = {
   price: number;
   allacts: string;
   website: string;
-  close: () => void;
+  close?: () => void;
 };
 
 function FestivalCardLarge({

--- a/src/components/FestivalCardLarge/FestivalCardLarge.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.tsx
@@ -46,7 +46,7 @@ function FestivalCardLarge({
             <span className={styles.item}>Acts</span>
             <span className={styles.item}>Price</span>
             <a href={website} className={styles.url}>
-              Official Website
+              Website
             </a>
           </div>
           <div className={styles.column}>
@@ -55,7 +55,7 @@ function FestivalCardLarge({
               {begin} — {end}
             </span>
             <span className={styles.item}>{visitors}</span>
-            <span className={styles.item}>{price}</span>
+            <span className={styles.item}>{price} €</span>
             <span className={styles.item}>{acts}</span>
           </div>
         </section>

--- a/src/components/FestivalCardLarge/FestivalCardLarge.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.tsx
@@ -1,14 +1,37 @@
 import Button from "../Buttons/Button";
 import styles from "./FestivalCardLarge.module.css";
 
-function FestivalCardLarge() {
+export type FestivalCardLargeProps = {
+  name: string;
+  location: string;
+  begin: string;
+  end: string;
+  visitors: number;
+  acts: number;
+  price: number;
+  allacts: string;
+  website: string;
+};
+
+function FestivalCardLarge({
+  name,
+  location,
+  begin,
+  end,
+  visitors,
+  acts,
+  price,
+  allacts,
+  website,
+}: FestivalCardLargeProps) {
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
         <section className={styles.header}>
-          <h3 className={styles.title}>Festival</h3>
+          <h3 className={styles.title}>{name}</h3>
           <img src="../../../lib/Icon_Close.svg" className={styles.close} />
         </section>
+
         <section className={styles.list}>
           <div className={styles.column}>
             <span className={styles.item}>Location</span>
@@ -16,19 +39,23 @@ function FestivalCardLarge() {
             <span className={styles.item}>Visitors</span>
             <span className={styles.item}>Acts</span>
             <span className={styles.item}>Price</span>
-            <a className={styles.url}>Official website</a>
+            <a href={website} className={styles.url}>
+              Official Website
+            </a>
           </div>
           <div className={styles.column}>
-            <span className={styles.item}>Value</span>
-            <span className={styles.item}>Value</span>
-            <span className={styles.item}>Value</span>
-            <span className={styles.item}>Value</span>
-            <span className={styles.item}>Value</span>
+            <span className={styles.item}>{location}</span>
+            <span className={styles.item}>
+              {begin} — {end}
+            </span>
+            <span className={styles.item}>{visitors}</span>
+            <span className={styles.item}>{price}</span>
+            <span className={styles.item}>{acts}</span>
           </div>
         </section>
         <section className={styles.acts}>
           <h4>Acts</h4>
-          <p>All the acts</p>
+          <p>{allacts}</p>
         </section>
         <div className={styles.button}>
           <Button size="small" text="Back to top" />

--- a/src/components/FestivalCardLarge/FestivalCardLarge.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.tsx
@@ -63,9 +63,6 @@ function FestivalCardLarge({
           <h4>Acts</h4>
           <p>{allacts}</p>
         </section>
-        <div className={styles.button}>
-          <Button size="small" text="Back to top" />
-        </div>
       </div>
     </div>
   );

--- a/src/components/FestivalCardLarge/FestivalCardLarge.tsx
+++ b/src/components/FestivalCardLarge/FestivalCardLarge.tsx
@@ -11,6 +11,7 @@ export type FestivalCardLargeProps = {
   price: number;
   allacts: string;
   website: string;
+  close: () => void;
 };
 
 function FestivalCardLarge({
@@ -23,13 +24,18 @@ function FestivalCardLarge({
   price,
   allacts,
   website,
-}: FestivalCardLargeProps) {
+  close,
+}: FestivalCardLargeProps): JSX.Element {
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
         <section className={styles.header}>
           <h3 className={styles.title}>{name}</h3>
-          <img src="../../../lib/Icon_Close.svg" className={styles.close} />
+          <img
+            src="../../../lib/Icon_Close.svg"
+            className={styles.close}
+            onClick={close}
+          />
         </section>
 
         <section className={styles.list}>

--- a/src/components/FestivalCardSmall/FestivalCardSmall.module.css
+++ b/src/components/FestivalCardSmall/FestivalCardSmall.module.css
@@ -31,3 +31,7 @@
   align-items: center;
   gap: 0.3rem;
 }
+
+.more {
+  cursor: pointer;
+}

--- a/src/components/FestivalCardSmall/FestivalCardSmall.stories.tsx
+++ b/src/components/FestivalCardSmall/FestivalCardSmall.stories.tsx
@@ -11,5 +11,6 @@ export const Card = () => (
     location="Dinkelsbühl"
     begin="17.08.2022"
     end="20.08.2022"
+    toSearch={() => ""}
   />
 );

--- a/src/components/FestivalCardSmall/FestivalCardSmall.tsx
+++ b/src/components/FestivalCardSmall/FestivalCardSmall.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useEffect } from "react";
 import styles from "./FestivalCardSmall.module.css";
 
 export type FestivalCardSmallProps = {
@@ -5,6 +7,7 @@ export type FestivalCardSmallProps = {
   location: string;
   begin: string;
   end: string;
+  toSearch: (value: string) => void;
 };
 
 function FestivalCardSmall({
@@ -12,7 +15,14 @@ function FestivalCardSmall({
   location,
   begin,
   end,
+  toSearch,
 }: FestivalCardSmallProps) {
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    toSearch(query);
+  }, [query]);
+
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
@@ -27,7 +37,7 @@ function FestivalCardSmall({
             {begin} {end}
           </span>
         </div>
-        <a>More</a>
+        <a onClick={() => setQuery(name)}>More</a>
       </div>
     </div>
   );

--- a/src/components/FestivalCardSmall/FestivalCardSmall.tsx
+++ b/src/components/FestivalCardSmall/FestivalCardSmall.tsx
@@ -37,7 +37,9 @@ function FestivalCardSmall({
             {begin} {end}
           </span>
         </div>
-        <a onClick={() => setQuery(name)}>More</a>
+        <a onClick={() => setQuery(name)} className={styles.more}>
+          More
+        </a>
       </div>
     </div>
   );

--- a/src/pages/AllFestivals/AllFestivals.tsx
+++ b/src/pages/AllFestivals/AllFestivals.tsx
@@ -30,7 +30,7 @@ function AllFestivals() {
   useEffect(() => {
     async function clickedFestival() {
       if (query != "") {
-        const response = await fetch(`/api/festivals/${query}`);
+        const response = await fetch(`/api/festivals/name/${query}`);
         const body = await response.json();
         setFestival(body);
       }

--- a/src/pages/AllFestivals/AllFestivals.tsx
+++ b/src/pages/AllFestivals/AllFestivals.tsx
@@ -38,7 +38,7 @@ function AllFestivals() {
     clickedFestival();
   }, [query]);
 
-  function showLargeFestivalCard() {
+  function close() {
     setFestival("");
   }
 
@@ -75,11 +75,11 @@ function AllFestivals() {
           </section>
         </>
       )}
-      <button onClick={() => showLargeFestivalCard()}> NULL</button>
 
       <section>
         {festival && (
           <FestivalCardLarge
+            close={() => close()}
             key=""
             name={festival.name}
             location={festival.location}

--- a/src/pages/AllFestivals/AllFestivals.tsx
+++ b/src/pages/AllFestivals/AllFestivals.tsx
@@ -11,7 +11,7 @@ import styles from "./AllFestivals.module.css";
 function AllFestivals() {
   const [festivals, setFestivals] = useState<FestivalCardSmallProps[]>([]);
   const [search, setSearch] = useState("");
-  const [festival, setFestival] = useState<FestivalCardLargeProps | null>(null);
+  const [festival, setFestival] = useState<FestivalCardLargeProps | "">("");
   const [query, setQuery] = useState<string | null>(null);
 
   const searchFestivals = festivals?.filter((festival) =>
@@ -29,17 +29,22 @@ function AllFestivals() {
 
   useEffect(() => {
     async function clickedFestival() {
-      const response = await fetch(`/api/festivals/${query}`);
-      const body = await response.json();
-      setFestival(body);
-      console.log(festival);
+      if (query != "") {
+        const response = await fetch(`/api/festivals/${query}`);
+        const body = await response.json();
+        setFestival(body);
+      }
     }
     clickedFestival();
   }, [query]);
 
+  function showLargeFestivalCard() {
+    setFestival("");
+  }
+
   return (
     <div className={styles.wrapper}>
-      {!query && (
+      {!festival && (
         <>
           <section className={styles.text}>
             <h1>All Festivals</h1>
@@ -70,10 +75,10 @@ function AllFestivals() {
           </section>
         </>
       )}
-      <button onClick={() => setQuery(null)}> NULL</button>
+      <button onClick={() => showLargeFestivalCard()}> NULL</button>
 
       <section>
-        {query && festival && (
+        {festival && (
           <FestivalCardLarge
             key=""
             name={festival.name}

--- a/src/pages/AllFestivals/AllFestivals.tsx
+++ b/src/pages/AllFestivals/AllFestivals.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useState } from "react";
+import FestivalCardLarge, {
+  FestivalCardLargeProps,
+} from "../../components/FestivalCardLarge/FestivalCardLarge";
 import FestivalCardSmall, {
   FestivalCardSmallProps,
 } from "../../components/FestivalCardSmall/FestivalCardSmall";
@@ -8,6 +11,8 @@ import styles from "./AllFestivals.module.css";
 function AllFestivals() {
   const [festivals, setFestivals] = useState<FestivalCardSmallProps[]>([]);
   const [search, setSearch] = useState("");
+  const [festival, setFestival] = useState<FestivalCardLargeProps | null>(null);
+  const [query, setQuery] = useState<string | null>(null);
 
   const searchFestivals = festivals?.filter((festival) =>
     festival.name.toLocaleLowerCase().includes(search.toLowerCase())
@@ -22,6 +27,16 @@ function AllFestivals() {
     getFestivals();
   }, []);
 
+  useEffect(() => {
+    async function clickedFestival() {
+      const response = await fetch(`/api/festivals/${query}`);
+      const body = await response.json();
+      setFestival(body);
+      console.log(festival);
+    }
+    clickedFestival();
+  }, [query]);
+
   return (
     <div className={styles.wrapper}>
       <section className={styles.text}>
@@ -35,6 +50,7 @@ function AllFestivals() {
         {searchFestivals?.length === 0 && (
           <span className={styles["no-documents"]}>No Docouments found</span>
         )}
+
         {searchFestivals?.map((festival) => (
           // eslint-disable-next-line react/jsx-key
           <FestivalCardSmall
@@ -42,8 +58,27 @@ function AllFestivals() {
             location={festival.location}
             begin={festival.begin}
             end={festival.end}
+            toSearch={setQuery}
           />
         ))}
+      </section>
+      <button onClick={() => setQuery(null)}> NULL</button>
+
+      <section>
+        {query && festival && (
+          <FestivalCardLarge
+            key=""
+            name={festival.name}
+            location={festival.location}
+            begin={festival.begin}
+            end={festival.end}
+            visitors={festival.visitors}
+            acts={festival.acts}
+            price={festival.price}
+            allacts={festival.allacts}
+            website={festival.website}
+          />
+        )}
       </section>
     </div>
   );

--- a/src/pages/AllFestivals/AllFestivals.tsx
+++ b/src/pages/AllFestivals/AllFestivals.tsx
@@ -39,29 +39,37 @@ function AllFestivals() {
 
   return (
     <div className={styles.wrapper}>
-      <section className={styles.text}>
-        <h1>All Festivals</h1>
-        <span className={styles.intro}>
-          Here’s an overview of all festivals in our database sorted by name.
-        </span>
-      </section>
-      <SearchBar onSearch={setSearch} />
-      <section className={styles.list}>
-        {searchFestivals?.length === 0 && (
-          <span className={styles["no-documents"]}>No Docouments found</span>
-        )}
+      {!query && (
+        <>
+          <section className={styles.text}>
+            <h1>All Festivals</h1>
 
-        {searchFestivals?.map((festival) => (
-          // eslint-disable-next-line react/jsx-key
-          <FestivalCardSmall
-            name={festival.name}
-            location={festival.location}
-            begin={festival.begin}
-            end={festival.end}
-            toSearch={setQuery}
-          />
-        ))}
-      </section>
+            <span className={styles.intro}>
+              Here’s an overview of all festivals in our database sorted by
+              name.
+            </span>
+          </section>
+          <SearchBar onSearch={setSearch} />
+          <section className={styles.list}>
+            {searchFestivals?.length === 0 && (
+              <span className={styles["no-documents"]}>
+                No Docouments found
+              </span>
+            )}
+
+            {searchFestivals?.map((festival) => (
+              // eslint-disable-next-line react/jsx-key
+              <FestivalCardSmall
+                name={festival.name}
+                location={festival.location}
+                begin={festival.begin}
+                end={festival.end}
+                toSearch={setQuery}
+              />
+            ))}
+          </section>
+        </>
+      )}
       <button onClick={() => setQuery(null)}> NULL</button>
 
       <section>


### PR DESCRIPTION
## ✅  Done
- [x] All information comes from API
- [x] Name of clicked festival on SmallFestivalCard-Component is passed to AllFestivals-page …
- [x] … and passed to FestivalCardLarge so the right festival is displayed
- [x] Add close-function close-button to FestivalCardLarge
- [x] Page should not rerender when close-button is clicked

## 🚧  TBD
CSS: Class _Container_ will be deleted when page is implemented 

## 🎉 Nice to have if there is some time left
• left column bold or medium
• back to top button
• Search bar should always have same size as the width of the FestivalCardSmall rows

https://user-images.githubusercontent.com/91462450/145705032-b528af3a-0d71-40ef-bd87-492ee1272c64.mov


